### PR TITLE
Feat/preview

### DIFF
--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -1,9 +1,5 @@
 use crate::LittIndexError::{
-    CreationError, 
-    OpenError, 
-    PdfParseError, 
-    PdfNotFoundError, 
-    WriteError
+    CreationError, OpenError, PdfNotFoundError, PdfParseError, WriteError,
 };
 use crate::Result;
 use litt_shared::search_schema::SearchSchema;

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -1,4 +1,10 @@
-use crate::LittIndexError::{CreationError, OpenError, PdfParseError, WriteError};
+use crate::LittIndexError::{
+    CreationError, 
+    OpenError, 
+    PdfParseError, 
+    PdfNotFoundError, 
+    WriteError
+};
 use crate::Result;
 use litt_shared::search_schema::SearchSchema;
 use lopdf::Document as PdfDocument;
@@ -64,12 +70,19 @@ impl Index {
         Ok(())
     }
 
-    pub fn index(self) -> TantivyIndex {
-        self.index
+    pub fn index(&self) -> &TantivyIndex {
+        &self.index
     }
 
     pub fn schema(self) -> SearchSchema {
         self.schema
+    }
+
+    pub fn get_page_body(&self, page: u32, path: &str) -> Result<String> {
+        let doc = PdfDocument::load(format!("{}/{}", self.path, path))
+            .map_err(|_e| PdfNotFoundError(format!("{}/{}", self.path, path)))?;
+        let text = doc.extract_text(&[page]).unwrap();
+        Ok(text)
     }
 
     fn create_index(path: String, schema: Schema) -> Result<TantivyIndex> {

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -9,6 +9,7 @@ pub enum LittIndexError {
     OpenError(String),
     WriteError(String),
     PdfParseError(String),
+    PdfNotFoundError(String),
 }
 
 impl fmt::Display for LittIndexError {
@@ -18,6 +19,7 @@ impl fmt::Display for LittIndexError {
             LittIndexError::OpenError(s) => write!(f, "Error opening existing index: {}", s),
             LittIndexError::WriteError(s) => write!(f, "Index Write Error: {}", s),
             LittIndexError::PdfParseError(s) => write!(f, "Error parsing PDF: {}", s),
+            LittIndexError::PdfNotFoundError(s) => write!(f, "PDF Not found: {}", s),
         }
     }
 }

--- a/litt/tests/tests.rs
+++ b/litt/tests/tests.rs
@@ -32,7 +32,13 @@ fn test_index_and_search() {
             for search_result in pages {
                 let preview = search.get_preview(search_result, &searched_word).unwrap();
                 assert!(!preview.is_empty());
-                assert!(preview.to_lowercase().find(&searched_word.to_lowercase()).unwrap_or_default() > 0);
+                assert!(
+                    preview
+                        .to_lowercase()
+                        .find(&searched_word.to_lowercase())
+                        .unwrap_or_default()
+                        > 0
+                );
                 assert!(preview.find("**").unwrap_or_default() > 0);
             }
         }

--- a/litt/tests/tests.rs
+++ b/litt/tests/tests.rs
@@ -31,7 +31,7 @@ fn test_index_and_search() {
             assert_eq!(title, TEST_FILE_NAME);
             for search_result in pages {
                 let preview = search.get_preview(search_result, &searched_word).unwrap();
-                assert!(preview.len() > 0);
+                assert!(!preview.is_empty());
                 assert!(preview.to_lowercase().find(&searched_word.to_lowercase()).unwrap_or_default() > 0);
                 assert!(preview.find("**").unwrap_or_default() > 0);
             }

--- a/litt/tests/tests.rs
+++ b/litt/tests/tests.rs
@@ -34,23 +34,9 @@ fn test_index_and_search() {
 
         for (title, pages) in &results {
             println!("\"{}\". Pages: {:?}", title, pages);
-            for page in pages {
-                let text = doc.extract_text(&[*page]).unwrap();
-                let preview_index = text
-                    .find(&searched_word)
-                    .expect("Searched word not found on page!");
-                let start = if preview_index > 50 {
-                    preview_index - 50
-                } else {
-                    0
-                };
-                let end = if (preview_index + searched_word.len() + 50) < text.len() {
-                    preview_index + searched_word.len() + 50
-                } else {
-                    text.len()
-                };
-                let preview = &text[start..end];
-                println!("- {}: \"{}\"", page, preview);
+            for search_result in pages {
+                let preview = search.get_preview(search_result, &searched_word).unwrap();
+                println!("- {}: \"{}\"", search_result.page, preview);
             }
         }
 

--- a/search/Cargo.toml
+++ b/search/Cargo.toml
@@ -9,3 +9,5 @@ crate-type = ["lib"]
 [dependencies]
 tantivy = "0.19.2"
 litt_shared = { path = "../shared" }
+litt_index = { path = "../index" }
+lopdf = { workspace = true }

--- a/search/src/lib.rs
+++ b/search/src/lib.rs
@@ -1,9 +1,21 @@
+use std::fmt;
+use std::fmt::Formatter;
+
 pub mod search;
 
 #[derive(Debug)]
 pub enum LittSearchError {
     InitError(String),
     SearchError(String),
+}
+
+impl fmt::Display for LittSearchError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match &self {
+            LittSearchError::InitError(s) => write!(f, "Error initializing new search: {}", s),
+            LittSearchError::SearchError(s) => write!(f, "Error during search: {}", s),
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, LittSearchError>;

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -11,6 +11,7 @@ use crate::LittSearchError::{InitError, SearchError};
 use crate::Result;
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct SearchResult {
     pub page: u32,
     segment_ord: u32,
@@ -186,14 +187,6 @@ mod tests {
         fresh and green with every spring, carrying in their lower leaf junctures the \
         debris of the winter’s flooding; and sycamores with mottled, white, recumbent \
         limbs and branches that arch over the pool";
-
-    impl PartialEq for SearchResult {
-        fn eq(&self, other: &Self) -> bool {
-            self.page == other.page
-                && self.segment_ord == other.segment_ord
-                && self.doc_id == other.doc_id
-        }
-    }
 
     fn setup() {
         create_dir_all(TEST_DIR_NAME)

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -30,6 +30,8 @@ impl SearchResult {
 impl PartialEq for SearchResult {
     fn eq(&self, other: &Self) -> bool {
         self.page == other.page
+            && self.segment_ord == other.segment_ord
+            && self.doc_id == other.doc_id
     }
 }
 

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, LinkedList};
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
-use tantivy::{DocAddress, IndexReader, ReloadPolicy, Score, SnippetGenerator, Snippet};
+use tantivy::{DocAddress, IndexReader, ReloadPolicy, Score, Snippet, SnippetGenerator};
 
 extern crate litt_index;
 use litt_index::index::Index;
@@ -12,27 +12,26 @@ use crate::Result;
 
 #[derive(Debug, Clone, Copy)]
 pub struct SearchResult {
-    pub page: u32, 
-    segment_ord: u32, 
-    doc_id: u32
+    pub page: u32,
+    segment_ord: u32,
+    doc_id: u32,
 }
 
-impl  SearchResult {
+impl SearchResult {
     pub fn new(page: u32, segment_ord: u32, doc_id: u32) -> Result<Self> {
         Ok(Self {
             page,
             segment_ord,
-            doc_id
+            doc_id,
         })
     }
 }
 
 impl PartialEq for SearchResult {
     fn eq(&self, other: &Self) -> bool {
-        self.page == other.page 
+        self.page == other.page
     }
 }
-
 
 pub struct Search {
     index: Index,
@@ -42,7 +41,8 @@ pub struct Search {
 
 impl Search {
     pub fn new(index: Index, schema: SearchSchema) -> Result<Self> {
-        let reader = index.index()
+        let reader = index
+            .index()
             .reader_builder()
             .reload_policy(ReloadPolicy::OnCommit)
             .try_into()
@@ -100,12 +100,11 @@ impl Search {
         Ok(results)
     }
 
-    pub fn get_preview(
-        &self,
-        search_result: &SearchResult,
-        input: &str,
-    ) -> Result<String> {
-        println!("Calling `get_preview` for: query: {} and page: {}", input, search_result.page);
+    pub fn get_preview(&self, search_result: &SearchResult, input: &str) -> Result<String> {
+        println!(
+            "Calling `get_preview` for: query: {} and page: {}",
+            input, search_result.page
+        );
         // Prepare creating snippet.
         let searcher = self.reader.searcher();
         let query_parser = QueryParser::for_index(self.index.index(), self.schema.default_fields());
@@ -114,9 +113,10 @@ impl Search {
             .map_err(|e| SearchError(e.to_string()))?;
         let snippet_generator = SnippetGenerator::create(&searcher, &*query, self.schema.body)
             .map_err(|e| SearchError(e.to_string()))?;
-        let retrieved_doc = searcher.doc(DocAddress { 
-                segment_ord: (search_result.segment_ord), 
-                doc_id: (search_result.doc_id) 
+        let retrieved_doc = searcher
+            .doc(DocAddress {
+                segment_ord: (search_result.segment_ord),
+                doc_id: (search_result.doc_id),
             })
             .map_err(|e| SearchError(e.to_string()))?;
 

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -56,7 +56,7 @@ impl Search {
 
     pub fn search(&self, input: &str) -> Result<HashMap<String, LinkedList<SearchResult>>> {
         let searcher = self.reader.searcher();
-        let query_parser = QueryParser::for_index(&self.index.index(), self.schema.default_fields());
+        let query_parser = QueryParser::for_index(self.index.index(), self.schema.default_fields());
 
         let query = query_parser
             .parse_query(input)
@@ -108,7 +108,7 @@ impl Search {
         println!("Calling `get_preview` for: query: {} and page: {}", input, search_result.page);
         // Prepare creating snippet.
         let searcher = self.reader.searcher();
-        let query_parser = QueryParser::for_index(&self.index.index(), self.schema.default_fields());
+        let query_parser = QueryParser::for_index(self.index.index(), self.schema.default_fields());
         let query = query_parser
             .parse_query(input)
             .map_err(|e| SearchError(e.to_string()))?;
@@ -212,7 +212,7 @@ mod tests {
 
         // Indexing documents
         let index_path = String::from(TEST_DIR_NAME);
-        let tantivy_index = tantivy::Index::create_in_dir(index_path, schema.clone()).unwrap();
+        let tantivy_index = tantivy::Index::create_in_dir(index_path, schema).unwrap();
         let mut index_writer = tantivy_index.writer(100_000_000).unwrap();
 
         const PAGE_1: u64 = 2;
@@ -238,7 +238,7 @@ mod tests {
 
         let search_schema = SearchSchema::default();
         let index = Index::open_or_create(TEST_DIR_NAME, search_schema.clone()).unwrap();
-        Search::new(index, search_schema.clone()).unwrap()
+        Search::new(index, search_schema).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Adds preview functionality by implementing tantivy snippet-generator

- changes search result from the list of pages to a list of type `SearchResult` to store additional information (like the id of the tantivy-document)
- adds function to `index` to retrieve the body of a given page at a path (needed for creating snippet)