### PR TITLE
fix: indexing

### DIFF
--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -21,7 +21,7 @@ pub struct Index {
 }
 
 impl Index {
-    pub fn create<P: AsRef<Path>>(path: P, schema: SearchSchema) -> Result<Self> {
+    pub fn create(path: impl AsRef<Path>, schema: SearchSchema) -> Result<Self> {
         let documents_path = PathBuf::from(path.as_ref());
         let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
         create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;
@@ -35,7 +35,7 @@ impl Index {
         })
     }
 
-    pub fn open_or_create<P: AsRef<Path>>(path: P, schema: SearchSchema) -> Result<Self> {
+    pub fn open_or_create(path: impl AsRef<Path>, schema: SearchSchema) -> Result<Self> {
         let documents_path = PathBuf::from(path.as_ref());
         let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
         create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -1,36 +1,52 @@
 use crate::LittIndexError::{
-    CreationError, OpenError, PdfNotFoundError, PdfParseError, WriteError,
+    CreationError, OpenError, PdfNotFoundError, PdfParseError, ReloadError, WriteError,
 };
 use crate::Result;
 use litt_shared::search_schema::SearchSchema;
 use lopdf::Document as PdfDocument;
+use std::fs::create_dir_all;
+use std::path::PathBuf;
+use tantivy::query::QueryParser;
 use tantivy::schema::{Document as TantivyDocument, Schema};
-use tantivy::{Index as TantivyIndex, IndexWriter};
+use tantivy::{Index as TantivyIndex, IndexReader, IndexWriter, ReloadPolicy, Searcher};
 use walkdir::{DirEntry, WalkDir};
 
+const INDEX_DIRECTORY_NAME: &str = ".litt-index";
+
 pub struct Index {
-    path: String,
+    documents_path: PathBuf,
     index: TantivyIndex,
+    reader: IndexReader,
     schema: SearchSchema,
 }
 
 impl Index {
     pub fn create(path: &str, schema: SearchSchema) -> Result<Self> {
-        let index = Self::create_index(path.to_string(), schema.schema.clone())?;
+        let documents_path = PathBuf::from(path);
+        let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
+        create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;
+        let index = Self::create_index(&index_path, schema.schema.clone())?;
+        let reader = Self::build_reader(&index)?;
         Ok(Self {
-            path: path.to_string(),
+            documents_path,
             index,
+            reader,
             schema,
         })
     }
 
     pub fn open_or_create(path: &str, schema: SearchSchema) -> Result<Self> {
-        let index = Self::create_index(path.to_string(), schema.schema.clone())
-            .unwrap_or(Self::open_index(path.to_string())?);
+        let documents_path = PathBuf::from(path);
+        let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
+        create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;
+        let index = Self::create_index(&index_path, schema.schema.clone())
+            .unwrap_or(Self::open_index(&index_path)?);
+        let reader = Self::build_reader(&index)?;
         // TODO make search schema parameter optional and load schema from existing index
         Ok(Self {
-            path: path.to_string(),
+            documents_path,
             index,
+            reader,
             schema,
         })
     }
@@ -70,27 +86,47 @@ impl Index {
         &self.index
     }
 
+    pub fn searcher(&self) -> Result<Searcher> {
+        self.reader
+            .reload()
+            .map_err(|e| ReloadError(e.to_string()))?;
+        Ok(self.reader.searcher())
+    }
+
+    pub fn query_parser(&self) -> QueryParser {
+        QueryParser::for_index(&self.index, self.schema.default_fields())
+    }
+
     pub fn schema(self) -> SearchSchema {
         self.schema
     }
 
     pub fn get_page_body(&self, page: u32, path: &str) -> Result<String> {
-        let doc = PdfDocument::load(format!("{}/{}", self.path, path))
-            .map_err(|_e| PdfNotFoundError(format!("{}/{}", self.path, path)))?;
+        let doc = PdfDocument::load(self.documents_path.join(path)).map_err(|_e| {
+            PdfNotFoundError(self.documents_path.join(path).to_string_lossy().to_string())
+        })?;
         let text = doc.extract_text(&[page]).unwrap();
         Ok(text)
     }
 
-    fn create_index(path: String, schema: Schema) -> Result<TantivyIndex> {
+    fn create_index(path: &PathBuf, schema: Schema) -> Result<TantivyIndex> {
         TantivyIndex::create_in_dir(path, schema).map_err(|e| CreationError(e.to_string()))
     }
 
-    fn open_index(path: String) -> Result<TantivyIndex> {
+    fn open_index(path: &PathBuf) -> Result<TantivyIndex> {
         TantivyIndex::open_in_dir(path).map_err(|e| OpenError(e.to_string()))
     }
 
+    fn build_reader(index: &TantivyIndex) -> Result<IndexReader> {
+        index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::OnCommit)
+            .try_into()
+            .map_err(|e| CreationError(e.to_string()))
+    }
+
     fn get_pdf_dir_entries(&self) -> Vec<DirEntry> {
-        let walk_dir = WalkDir::new(self.path.clone());
+        let walk_dir = WalkDir::new(&self.documents_path);
         walk_dir
             .follow_links(true)
             .into_iter()
@@ -158,7 +194,7 @@ mod tests {
     static SEARCH_SCHEMA: Lazy<SearchSchema> = Lazy::new(SearchSchema::default);
 
     fn setup() {
-        save_fake_pdf_document(TEST_DIR_NAME, TEST_FILE_PATH);
+        save_fake_pdf_document(TEST_DIR_NAME, TEST_FILE_PATH, vec!["Hello, world".into()]);
     }
 
     fn teardown() {
@@ -183,9 +219,8 @@ mod tests {
     fn test_create() {
         run_test(|| {
             let index = Index::create(TEST_DIR_NAME, SEARCH_SCHEMA.clone()).unwrap();
-
             assert_eq!(SEARCH_SCHEMA.clone().schema, index.schema.schema);
-            assert_eq!(TEST_DIR_NAME, index.path);
+            assert_eq!(PathBuf::from(TEST_DIR_NAME), index.documents_path);
         });
     }
 
@@ -198,7 +233,7 @@ mod tests {
             let opened_index = Index::open_or_create(TEST_DIR_NAME, SEARCH_SCHEMA.clone()).unwrap();
 
             assert_eq!(SEARCH_SCHEMA.clone().schema, opened_index.schema.schema);
-            assert_eq!(TEST_DIR_NAME, opened_index.path);
+            assert_eq!(PathBuf::from(TEST_DIR_NAME), opened_index.documents_path);
         });
     }
 

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -3,7 +3,9 @@ use crate::LittIndexError::{
 };
 use crate::Result;
 use litt_shared::search_schema::SearchSchema;
+use litt_shared::LITT_DIRECTORY_NAME;
 use lopdf::Document as PdfDocument;
+use std::convert::AsRef;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use tantivy::query::QueryParser;
@@ -11,7 +13,7 @@ use tantivy::schema::{Document as TantivyDocument, Schema};
 use tantivy::{Index as TantivyIndex, IndexReader, IndexWriter, ReloadPolicy, Searcher};
 use walkdir::{DirEntry, WalkDir};
 
-const INDEX_DIRECTORY_NAME: &str = ".litt-index";
+const INDEX_DIRECTORY_NAME: &str = "index";
 
 pub struct Index {
     documents_path: PathBuf,
@@ -23,7 +25,9 @@ pub struct Index {
 impl Index {
     pub fn create(path: impl AsRef<Path>, schema: SearchSchema) -> Result<Self> {
         let documents_path = PathBuf::from(path.as_ref());
-        let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
+        let index_path = documents_path
+            .join(LITT_DIRECTORY_NAME)
+            .join(INDEX_DIRECTORY_NAME);
         create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;
         let index = Self::create_index(&index_path, schema.schema.clone())?;
         let reader = Self::build_reader(&index)?;
@@ -234,6 +238,10 @@ mod tests {
 
             assert_eq!(SEARCH_SCHEMA.clone().schema, opened_index.schema.schema);
             assert_eq!(PathBuf::from(TEST_DIR_NAME), opened_index.documents_path);
+            assert!(Path::new(TEST_DIR_NAME)
+                .join(LITT_DIRECTORY_NAME)
+                .join(INDEX_DIRECTORY_NAME)
+                .is_dir())
         });
     }
 

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -5,7 +5,7 @@ use crate::Result;
 use litt_shared::search_schema::SearchSchema;
 use lopdf::Document as PdfDocument;
 use std::fs::create_dir_all;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tantivy::query::QueryParser;
 use tantivy::schema::{Document as TantivyDocument, Schema};
 use tantivy::{Index as TantivyIndex, IndexReader, IndexWriter, ReloadPolicy, Searcher};
@@ -21,8 +21,8 @@ pub struct Index {
 }
 
 impl Index {
-    pub fn create(path: &str, schema: SearchSchema) -> Result<Self> {
-        let documents_path = PathBuf::from(path);
+    pub fn create<P: AsRef<Path>>(path: P, schema: SearchSchema) -> Result<Self> {
+        let documents_path = PathBuf::from(path.as_ref());
         let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
         create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;
         let index = Self::create_index(&index_path, schema.schema.clone())?;
@@ -35,8 +35,8 @@ impl Index {
         })
     }
 
-    pub fn open_or_create(path: &str, schema: SearchSchema) -> Result<Self> {
-        let documents_path = PathBuf::from(path);
+    pub fn open_or_create<P: AsRef<Path>>(path: P, schema: SearchSchema) -> Result<Self> {
+        let documents_path = PathBuf::from(path.as_ref());
         let index_path = documents_path.join(INDEX_DIRECTORY_NAME);
         create_dir_all(&index_path).map_err(|e| CreationError(e.to_string()))?;
         let index = Self::create_index(&index_path, schema.schema.clone())

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -101,8 +101,8 @@ impl Index {
         self.schema
     }
 
-    pub fn get_page_body(&self, page: u32, path: &str) -> Result<String> {
-        let doc = PdfDocument::load(self.documents_path.join(path)).map_err(|_e| {
+    pub fn get_page_body(&self, page: u32, path: impl AsRef<Path>) -> Result<String> {
+        let doc = PdfDocument::load(self.documents_path.join(path.as_ref())).map_err(|_e| {
             PdfNotFoundError(self.documents_path.join(path).to_string_lossy().to_string())
         })?;
         let text = doc.extract_text(&[page]).unwrap();

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -7,6 +7,7 @@ pub mod index;
 pub enum LittIndexError {
     CreationError(String),
     OpenError(String),
+    ReloadError(String),
     WriteError(String),
     PdfParseError(String),
     PdfNotFoundError(String),
@@ -20,6 +21,7 @@ impl fmt::Display for LittIndexError {
             LittIndexError::WriteError(s) => write!(f, "Index Write Error: {}", s),
             LittIndexError::PdfParseError(s) => write!(f, "Error parsing PDF: {}", s),
             LittIndexError::PdfNotFoundError(s) => write!(f, "PDF Not found: {}", s),
+            LittIndexError::ReloadError(s) => write!(f, "Error reloading index writer: {}", s),
         }
     }
 }

--- a/litt/tests/tests.rs
+++ b/litt/tests/tests.rs
@@ -49,7 +49,7 @@ fn test_index_and_search() {
 }
 
 fn setup() {
-    save_fake_pdf_document(TEST_DIR_NAME, TEST_FILE_PATH);
+    save_fake_pdf_document(TEST_DIR_NAME, TEST_FILE_PATH, vec!["Hello, world".into()]);
 }
 
 fn teardown() {

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -1,13 +1,12 @@
 use std::collections::{HashMap, LinkedList};
 use tantivy::collector::TopDocs;
-use tantivy::query::QueryParser;
-use tantivy::{DocAddress, IndexReader, ReloadPolicy, Score, Snippet, SnippetGenerator};
+use tantivy::{DocAddress, Score, Snippet, SnippetGenerator};
 
 extern crate litt_index;
 use litt_index::index::Index;
 use litt_shared::search_schema::SearchSchema;
 
-use crate::LittSearchError::{InitError, SearchError};
+use crate::LittSearchError::SearchError;
 use crate::Result;
 
 #[derive(Debug, Clone, Copy)]
@@ -30,28 +29,20 @@ impl SearchResult {
 
 pub struct Search {
     index: Index,
-    reader: IndexReader,
     schema: SearchSchema,
 }
 
 impl Search {
     pub fn new(index: Index, schema: SearchSchema) -> Result<Self> {
-        let reader = index
-            .index()
-            .reader_builder()
-            .reload_policy(ReloadPolicy::OnCommit)
-            .try_into()
-            .map_err(|e| InitError(e.to_string()))?;
-        Ok(Self {
-            index,
-            reader,
-            schema,
-        })
+        Ok(Self { index, schema })
     }
 
     pub fn search(&self, input: &str) -> Result<HashMap<String, LinkedList<SearchResult>>> {
-        let searcher = self.reader.searcher();
-        let query_parser = QueryParser::for_index(self.index.index(), self.schema.default_fields());
+        let searcher = self
+            .index
+            .searcher()
+            .map_err(|e| SearchError(e.to_string()))?;
+        let query_parser = self.index.query_parser();
 
         let query = query_parser
             .parse_query(input)
@@ -108,8 +99,11 @@ impl Search {
 
     pub fn get_preview(&self, search_result: &SearchResult, input: &str) -> Result<String> {
         // Prepare creating snippet.
-        let searcher = self.reader.searcher();
-        let query_parser = QueryParser::for_index(self.index.index(), self.schema.default_fields());
+        let searcher = self
+            .index
+            .searcher()
+            .map_err(|e| SearchError(e.to_string()))?;
+        let query_parser = self.index.query_parser();
         let query = query_parser
             .parse_query(input)
             .map_err(|e| SearchError(e.to_string()))?;
@@ -162,19 +156,13 @@ impl Search {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs::{create_dir_all, remove_dir_all},
-        panic,
-    };
+    use std::panic;
 
-    use tantivy::{
-        doc,
-        schema::{Schema, STORED, TEXT},
-    };
+    use litt_shared::test_helpers::{cleanup_dir_and_file, save_fake_pdf_document};
 
     use super::*;
     const TEST_DIR_NAME: &str = "resources";
-    const TEST_DOC_NAME: &str = "Of Mice and Men";
+    const TEST_DOC_NAME: &str = "test";
     const TEST_FILE_PATH: &str = "test.pdf";
     const BODY_1: &str =
         "A few miles south of Soledad, the Salinas River drops in close to the hillside \
@@ -189,13 +177,15 @@ mod tests {
         limbs and branches that arch over the pool";
 
     fn setup() {
-        create_dir_all(TEST_DIR_NAME)
-            .unwrap_or_else(|_| panic!("Failed to create directory: {}", TEST_DIR_NAME));
+        save_fake_pdf_document(
+            TEST_DIR_NAME,
+            TEST_FILE_PATH,
+            vec![BODY_1.into(), BODY_2.into()],
+        )
     }
 
     fn teardown() {
-        remove_dir_all(TEST_DIR_NAME)
-            .unwrap_or_else(|_| panic!("Failed to remove directory: {}", TEST_DIR_NAME));
+        cleanup_dir_and_file(TEST_DIR_NAME, TEST_FILE_PATH);
     }
 
     fn run_test<T>(test: T)
@@ -212,41 +202,9 @@ mod tests {
     }
 
     fn create_searcher() -> Search {
-        let mut schema_builder = Schema::builder();
-        let title = schema_builder.add_text_field("title", TEXT | STORED);
-        let path = schema_builder.add_text_field("path", TEXT | STORED);
-        let page = schema_builder.add_u64_field("page", STORED);
-        let body = schema_builder.add_text_field("body", TEXT);
-        let schema = schema_builder.build();
-
-        // Indexing documents
-        let index_path = String::from(TEST_DIR_NAME);
-        let tantivy_index = tantivy::Index::create_in_dir(index_path, schema).unwrap();
-        let mut index_writer = tantivy_index.writer(100_000_000).unwrap();
-
-        const PAGE_1: u64 = 2;
-        index_writer
-            .add_document(doc!(
-                title => TEST_DOC_NAME,
-                path => TEST_FILE_PATH,
-                page => PAGE_1,
-                body => BODY_1
-            ))
-            .unwrap();
-
-        const PAGE_2: u64 = 2;
-        index_writer
-            .add_document(doc!(
-                title => TEST_DOC_NAME,
-                path => TEST_FILE_PATH,
-                page => PAGE_2,
-                body => BODY_2
-            ))
-            .unwrap();
-        index_writer.commit().unwrap();
-
         let search_schema = SearchSchema::default();
         let index = Index::open_or_create(TEST_DIR_NAME, search_schema.clone()).unwrap();
+        index.add_all_documents().unwrap();
         Search::new(index, search_schema).unwrap()
     }
 
@@ -262,8 +220,9 @@ mod tests {
         // one-word search returning 1 result with 1 page
         let results = search.search(&String::from("flooding")).unwrap();
         assert!(results.contains_key(TEST_DOC_NAME));
-        assert_eq!(results.get(TEST_DOC_NAME).unwrap().len(), 1);
-        assert_eq!(results.get(TEST_DOC_NAME).unwrap().front().unwrap().page, 2);
+        assert_eq!(1, results.get(TEST_DOC_NAME).unwrap().len());
+        let first_result = results.get(TEST_DOC_NAME).unwrap().front().unwrap();
+        assert_eq!(2, first_result.page);
 
         // one-word search returning 1 result with two pages
         let results = search.search(&String::from("the")).unwrap();

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod search_schema;
 pub mod test_helpers;
+
+/// directory used to store any persisted data for an individual index, e.g. tantivy index data.
+pub const LITT_DIRECTORY_NAME: &str = ".litt";

--- a/shared/src/test_helpers.rs
+++ b/shared/src/test_helpers.rs
@@ -6,7 +6,7 @@ use lopdf::{Document, Object, Stream};
 
 /// Generate a fake pdf document.
 /// Source: [github.com/J-F-Liu/lopdf](https://github.com/J-F-Liu/lopdf#example-code)
-pub fn generate_fake_pdf_document() -> Document {
+pub fn generate_fake_pdf_document(page_texts: Vec<String>) -> Document {
     let mut doc = Document::with_version("1.5");
     let pages_id = doc.new_object_id();
     let font_id = doc.add_object(dictionary! {
@@ -19,42 +19,52 @@ pub fn generate_fake_pdf_document() -> Document {
             "F1" => font_id,
         },
     });
-    let content = Content {
-        operations: vec![
-            Operation::new("BT", vec![]),
-            Operation::new("Tf", vec!["F1".into(), 48.into()]),
-            Operation::new("Td", vec![100.into(), 600.into()]),
-            Operation::new("Tj", vec![Object::string_literal("Hello World!")]),
-            Operation::new("ET", vec![]),
-        ],
-    };
-    let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
-    let page_id = doc.add_object(dictionary! {
-        "Type" => "Page",
-        "Parent" => pages_id,
-        "Contents" => content_id,
-        "Resources" => resources_id,
-        "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
-    });
+    let mut page_ids = vec![];
+    for text in page_texts {
+        let content = Content {
+            operations: vec![
+                Operation::new("BT", vec![]),
+                Operation::new("Tf", vec!["F1".into(), 48.into()]),
+                Operation::new("Td", vec![100.into(), 600.into()]),
+                Operation::new("Tj", vec![Object::string_literal(text)]),
+                Operation::new("ET", vec![]),
+            ],
+        };
+        let content_id = doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+        let page_id = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_id,
+            "Resources" => resources_id,
+            "MediaBox" => vec![0.into(), 0.into(), 595.into(), 842.into()],
+        });
+        page_ids.push(page_id);
+    }
+
     let pages = dictionary! {
         "Type" => "Pages",
-        "Kids" => vec![page_id.into()],
-        "Count" => 1,
+        "Kids" => page_ids.clone()
+            .into_iter()
+            .map(Object::Reference)
+            .collect::<Vec<_>>(),
+        "Count" => page_ids.len() as u32,
     };
+
     doc.objects.insert(pages_id, Object::Dictionary(pages));
     let catalog_id = doc.add_object(dictionary! {
         "Type" => "Catalog",
         "Pages" => pages_id,
     });
+
     doc.trailer.set("Root", catalog_id);
 
     doc
 }
 
-pub fn save_fake_pdf_document(directory: &str, file_name: &str) {
+pub fn save_fake_pdf_document(directory: &str, file_name: &str, page_texts: Vec<String>) {
     create_dir_all(directory)
         .unwrap_or_else(|_| panic!("Failed to create directory: {}", directory));
-    let mut doc = generate_fake_pdf_document();
+    let mut doc = generate_fake_pdf_document(page_texts);
     doc.save(format!("{}/{}", directory, file_name))
         .unwrap_or_else(|_| panic!("Failed to save test document: {}", file_name));
 }


### PR DESCRIPTION
- fix indexing
- decouple index and search, so that the tantivy index doesn't need to be exposed anymore
- refactor test helper functions
- use the `PathBuf` type instead of `String` for paths in the index for cross-platform compatibility