### PR TITLE
feat: update the index at the given path

### DIFF
--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -87,9 +87,6 @@ impl Index {
         self.reader.reload().map_err(|e| ReloadError(e.to_string()))
     }
 
-    pub fn index(&self) -> &TantivyIndex {
-        &self.index
-    }
 
     pub fn searcher(&self) -> Searcher {
         self.reader.searcher()
@@ -99,9 +96,6 @@ impl Index {
         QueryParser::for_index(&self.index, self.schema.default_fields())
     }
 
-    pub fn schema(self) -> SearchSchema {
-        self.schema
-    }
 
     pub fn get_page_body(&self, page: u32, path: impl AsRef<Path>) -> Result<String> {
         let doc = PdfDocument::load(self.documents_path.join(path.as_ref())).map_err(|_e| {

--- a/index/src/index.rs
+++ b/index/src/index.rs
@@ -94,9 +94,6 @@ impl Index {
         self.writer
             .delete_all_documents()
             .map_err(|e| UpdateError(e.to_string()))?;
-        self.writer
-            .commit()
-            .map_err(|e| UpdateError(e.to_string()))?;
         self.add_all_pdf_documents()
     }
 

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -6,6 +6,7 @@ pub mod index;
 #[derive(Debug)]
 pub enum LittIndexError {
     CreationError(String),
+    UpdateError(String),
     OpenError(String),
     ReloadError(String),
     WriteError(String),
@@ -18,6 +19,7 @@ impl fmt::Display for LittIndexError {
         match &self {
             LittIndexError::CreationError(s) => write!(f, "Index Creation Error: {}", s),
             LittIndexError::OpenError(s) => write!(f, "Error opening existing index: {}", s),
+            LittIndexError::UpdateError(s) => write!(f, "Error updating the index: {}", s),
             LittIndexError::WriteError(s) => write!(f, "Index Write Error: {}", s),
             LittIndexError::PdfParseError(s) => write!(f, "Error parsing PDF: {}", s),
             LittIndexError::PdfNotFoundError(s) => write!(f, "PDF Not found: {}", s),

--- a/litt/tests/tests.rs
+++ b/litt/tests/tests.rs
@@ -15,7 +15,7 @@ fn test_index_and_search() {
     run_test(|| {
         let search_schema = SearchSchema::default();
 
-        let index = Index::create(TEST_DIR_NAME, search_schema.clone()).unwrap();
+        let mut index = Index::create(TEST_DIR_NAME, search_schema.clone()).unwrap();
         index.add_all_pdf_documents().unwrap();
 
         // # Searching

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -196,7 +196,7 @@ mod tests {
 
     fn create_searcher() -> Search {
         let search_schema = SearchSchema::default();
-        let index = Index::open_or_create(TEST_DIR_NAME, search_schema.clone()).unwrap();
+        let mut index = Index::open_or_create(TEST_DIR_NAME, search_schema.clone()).unwrap();
         index.add_all_pdf_documents().unwrap();
         Search::new(index, search_schema)
     }


### PR DESCRIPTION
Closes #14.

- Adds a simple implementation of `update()` on the index, which just deletes current index and indexes again

I decided to discard the idea of holding a set of already indexed file names in the index struct, as this wouldn't handle file changes or replacements. After thinking back and forth, I think for the time being, deleting the index and re-indexing all documents is good enough, not efficient, but at least correct / behaving as the user would expect.
